### PR TITLE
Assign /product path to example-provider

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -12,7 +12,7 @@ const mswPact = setupPactMswAdapter({
   options: {
     consumer: process.env.PACT_CONSUMER ? process.env.PACT_CONSUMER : 'pactflow-example-consumer-msw',
     providers: {
-      [process.env.PACT_PROVIDER ? process.env.PACT_PROVIDER : 'pactflow-example-provider-dredd']: ['products']
+      [process.env.PACT_PROVIDER ? process.env.PACT_PROVIDER : 'pactflow-example-provider-dredd']: ['products', 'product']
     },
     pactOutDir: './pacts',
     excludeHeaders: ['x-powered-by']


### PR DESCRIPTION
When looking at this example I realised that the whole contract as was being tested was not being recorded. Eventually I figured out that we need to tell the MSW adapter which endpoints belong to which provider, which makes sense. Adding this to the parameters for setupPactMswAdapter